### PR TITLE
modify PacketSerialDevice_ class: using setDataTerminalReady and getP…

### DIFF
--- a/libs/ofxSerial/include/ofx/IO/PacketSerialDevice.h
+++ b/libs/ofxSerial/include/ofx/IO/PacketSerialDevice.h
@@ -53,6 +53,10 @@ public:
     using BufferedSerialDevice::isRingIndicated;
     using BufferedSerialDevice::isCarrierDetected;
     using BufferedSerialDevice::isOpen;
+	using BufferedSerialDevice::setDataTerminalReady;
+	using BufferedSerialDevice::getPortName;
+
+	
 
     /// \brief Register a class to receive notifications for all events.
     /// \param listener a pointer to the listener class.


### PR DESCRIPTION
Dear bakercp!

as requested here comes a pull request for my [open issue](https://github.com/bakercp/ofxSerial/issues/13). It was an easy fix. Besides `setDataTerminalReady ` I also added `getPortName`, which was available in 0.9.8 branch, but is not in 0.10 branch. So you might have cleaned it by purpose - in this case please igonre.

Thank you very much for helping so quickly - and generally for your incredible work!

have a good day
oe